### PR TITLE
add Structured Data Extraction recipe

### DIFF
--- a/.github/notebook_lists/vanilla_notebooks.txt
+++ b/.github/notebook_lists/vanilla_notebooks.txt
@@ -1,2 +1,3 @@
 recipes/QuickStart/QuickStart.ipynb
 recipes/InstructValidateRepair/InstructValidateRepair.ipynb
+recipes/StructuredDataExtraction/StructuredDataExtraction.ipynb

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The "Recipes" in the Mellea Cookbook showcase the capabilities of Mellea, in bit
    <a target="_blank" href="https://colab.research.google.com/github/generative-computing/mellea-cookbook/blob/main/recipes/InstructValidateRepair/InstructValidateRepair.ipynb">
    <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
    </a>
+1. [Extracting Structured Data from Unstructured Text](recipes/StructuredDataExtraction/StructuredDataExtraction.ipynb)
+   <a target="_blank" href="https://colab.research.google.com/github/ibm-granite-community/mellea-cookbook/blob/main/recipes/StructuredDataExtraction/StructuredDataExtraction.ipynb">
+   <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
+   </a>
 
 ## Build Status
 

--- a/StructuredSentimentClassifier/Readme.md
+++ b/StructuredSentimentClassifier/Readme.md
@@ -1,1 +1,1 @@
-Structured Sentiment Classifier
+# Structured Sentiment Classifier

--- a/recipes/StructuredDataExtraction/StructuredDataExtraction.ipynb
+++ b/recipes/StructuredDataExtraction/StructuredDataExtraction.ipynb
@@ -42,6 +42,7 @@
    },
    "outputs": [],
    "source": [
+    "%pip install -q git+https://github.com/ibm-granite-community/utils\n",
     "%pip install -q mellea pydantic"
    ]
   },

--- a/recipes/StructuredDataExtraction/StructuredDataExtraction.ipynb
+++ b/recipes/StructuredDataExtraction/StructuredDataExtraction.ipynb
@@ -1,0 +1,630 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2VXy43AhUnYZ"
+   },
+   "source": [
+    "# Extracting Structured Data from Unstructured Text\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ibm-granite-community/mellea-cookbook/blob/main/recipes/StructuredDataExtraction/StructuredDataExtraction.ipynb)\n",
+    "\n",
+    "Data sources like invoices, emails, and support tickets rarely arrive in clean, machine-readable formats. Traditional extraction methods rely on regular expressions and custom JSON parsers, which are difficult to maintain and frequently fail when document layouts change.\n",
+    "\n",
+    "This guide demonstrates an alternative approach. By defining the target data structure as a typed Python schema, Mellea manages prompt construction, model execution, schema validation, and automatic retries.\n",
+    "\n",
+    "**What you will learn:**\n",
+    "\n",
+    "- Limitations of regex and manual JSON parsing for text extraction\n",
+    "- Using `@generative` stubs to map Pydantic schemas to extraction functions\n",
+    "- Using `instruct(format=...)` for dynamic prompts and structured output\n",
+    "- Implementation patterns for invoices, emails, and support tickets\n",
+    "- Applying `requirements` for domain constraints and error recovery\n",
+    "\n",
+    "**Prerequisites:** Ollama running locally with `granite4.1:3b` pulled, **or** an OpenAI-compatible API key (see *Backend Setup* below)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "XJMnDYsOUnYc"
+   },
+   "source": [
+    "## Install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "GQxuhsuDUnYd"
+   },
+   "outputs": [],
+   "source": [
+    "%pip install -q mellea pydantic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "cW4gCwgwUnYe"
+   },
+   "source": [
+    "## Backend setup\n",
+    "\n",
+    "This notebook runs IBM Granite locally via Ollama. The cells below install Ollama,\n",
+    "start the server, and pull the model, no API keys required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "smId3B-bUnYf"
+   },
+   "outputs": [],
+   "source": [
+    "# Install Ollama\n",
+    "!sudo apt-get install -y zstd\n",
+    "!curl -fsSL https://ollama.com/install.sh | sh\n",
+    "\n",
+    "# Start the Ollama daemon in the background\n",
+    "import subprocess\n",
+    "import time\n",
+    "subprocess.Popen([\"ollama\", \"serve\"])\n",
+    "time.sleep(5)\n",
+    "\n",
+    "# Pull the IBM Granite model\n",
+    "!ollama pull granite4.1:8b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "7LQNUjkrWxTr"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from mellea import start_session\n",
+    "\n",
+    "os.environ[\"LITELLM_MODEL\"] = \"ollama/granite4.1:8b\"\n",
+    "\n",
+    "m = start_session()\n",
+    "print(\"Session ready:\", m)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "OP23s9-UUnYg"
+   },
+   "source": [
+    "## Traditional extraction: regex limitations\n",
+    "\n",
+    "Before implementing LLM-based solutions, it is useful to review the standard regex approach. The following code shows a typical regex-based extractor for invoice data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "W0hDguNGUnYh"
+   },
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "\n",
+    "def extract_invoice_fragile(text: str) -> dict:\n",
+    "    \"\"\"Traditional regex approach — breaks on format variation.\"\"\"\n",
+    "    invoice_no = re.search(r'Invoice\\s*#?\\s*([\\w-]+)', text)\n",
+    "    total      = re.search(r'Total[:\\s]+\\$?([\\d,\\.]+)', text)\n",
+    "    due_date   = re.search(r'Due[:\\s]+(\\d{1,2}[/-]\\d{1,2}[/-]\\d{2,4})', text)\n",
+    "    return {\n",
+    "        \"invoice_number\": invoice_no.group(1) if invoice_no else None,\n",
+    "        \"total\":          total.group(1)      if total      else None,\n",
+    "        \"due_date\":       due_date.group(1)   if due_date   else None,\n",
+    "    }\n",
+    "\n",
+    "# Works on a clean, predictable format:\n",
+    "clean = \"Invoice #INV-2024-089  Total: $1,450.00  Due: 05/30/2024\"\n",
+    "print(\"Clean: \", extract_invoice_fragile(clean))\n",
+    "\n",
+    "# Fails on real-world variation:\n",
+    "messy_invoice = \"\"\"\n",
+    "    Ref: 2024-089 | Mao-Kwikowski Mercantile\n",
+    "    Issued 3rd March 2024 — Payment by: 30 May 2024\n",
+    "\n",
+    "    Items ordered:\n",
+    "      - Widget Pro x 5 @ 150 USD each\n",
+    "      - Mounting Kit x 2 @ 50 USD each\n",
+    "      - Express Shipping (flat fee): 100 USD\n",
+    "\n",
+    "    Amount due: USD 950 (excl. VAT)\n",
+    "    Bank transfer to: Tycho Bank, IBAN XX00 0000 0000\n",
+    "\"\"\"\n",
+    "print(\"Messy:\", extract_invoice_fragile(messy_invoice))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "nb-wIAiiUnYi"
+   },
+   "source": [
+    "The regex fails to extract any fields from the unstructured version. In production environments, invoices originate from multiple vendors with varying layouts. Maintaining distinct regular expressions for each variation is not scalable.\n",
+    "\n",
+    "The declarative approach allows you to define the schema once and delegate format normalization to the model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Xx80qPQvUnYj"
+   },
+   "source": [
+    "## Pattern 1: Using `@generative` stubs with Pydantic schemas\n",
+    "\n",
+    "A `@generative` stub is a body-less Python function. The decorator translates the function signature into a structured LLM call based on three components:\n",
+    "\n",
+    "- **Docstring:** The task description (system prompt)\n",
+    "- **Parameter names:** The input variables provided to the model\n",
+    "- **Return annotation:** The Pydantic schema enforcing the output structure\n",
+    "\n",
+    "The returned object is guaranteed to be a validated instance of the specified type. If the model generates invalid output, Mellea automatically initiates a retry sequence.\n",
+    "\n",
+    "### Example: Parsing an unstructured invoice"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "oXk_t7k1UnYk"
+   },
+   "outputs": [],
+   "source": [
+    "from typing import List, Optional\n",
+    "from pydantic import BaseModel\n",
+    "from mellea import generative\n",
+    "\n",
+    "\n",
+    "class LineItem(BaseModel):\n",
+    "    description: str\n",
+    "    quantity: int\n",
+    "    unit_price: float\n",
+    "\n",
+    "\n",
+    "class Invoice(BaseModel):\n",
+    "    invoice_number: str\n",
+    "    vendor_name: str\n",
+    "    issue_date: Optional[str] = None   # ISO 8601 when present\n",
+    "    due_date: Optional[str] = None\n",
+    "    line_items: List[LineItem]\n",
+    "    total_amount: float\n",
+    "    currency: str\n",
+    "\n",
+    "\n",
+    "@generative\n",
+    "def parse_invoice(text: str) -> Invoice:\n",
+    "    \"\"\"Parse the invoice text and extract all fields.\n",
+    "    For each line item, extract description as product name only (without quantity or price),\n",
+    "    quantity as integer, and unit_price as float.\n",
+    "    Convert all dates to ISO 8601 format (YYYY-MM-DD).\n",
+    "    If a field is not present in the text, return null.\"\"\"\n",
+    "    ...\n",
+    "\n",
+    "invoice = parse_invoice(m, text=messy_invoice)\n",
+    "print(invoice.model_dump_json(indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "s7WzfvxEUnYm"
+   },
+   "source": [
+    "The `parse_invoice` function processes varying invoice layouts, date formats, and currency symbols without requiring code modifications.\n",
+    "\n",
+    "The extracted fields are accessible directly on the typed object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "tjg_81BNUnYm"
+   },
+   "outputs": [],
+   "source": [
+    "print(f\"Invoice:  {invoice.invoice_number}\")\n",
+    "print(f\"Vendor:   {invoice.vendor_name}\")\n",
+    "print(f\"Due:      {invoice.due_date}\")\n",
+    "print(f\"Total:    {invoice.total_amount} {invoice.currency}\")\n",
+    "for item in invoice.line_items:\n",
+    "    print(f\"  {item.quantity}x {item.description} @ {item.unit_price}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TcL-jlZ3UnYn"
+   },
+   "source": [
+    "### Example: Extracting contact details from an email thread\n",
+    "\n",
+    "Email threads often contain quoted headers, inline replies, and signature blocks. A `@generative` stub isolates the requested entities and ignores irrelevant text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "eifNrFpRUnYn"
+   },
+   "outputs": [],
+   "source": [
+    "from typing import Optional\n",
+    "from pydantic import BaseModel\n",
+    "from mellea import generative\n",
+    "\n",
+    "\n",
+    "class ContactRecord(BaseModel):\n",
+    "    full_name: str\n",
+    "    email: str\n",
+    "    phone: Optional[str] = None\n",
+    "    company: Optional[str] = None\n",
+    "    role: Optional[str] = None\n",
+    "\n",
+    "\n",
+    "@generative\n",
+    "def extract_contact(text: str) -> ContactRecord:\n",
+    "    \"\"\"Extract the primary sender's contact information from the email thread.\n",
+    "    Focus on the most recent message. Extract email address from the From: header.\n",
+    "    Extract company name separately from job role.\n",
+    "    Return null for any field not present.\"\"\"\n",
+    "    ...\n",
+    "\n",
+    "\n",
+    "messy_email = \"\"\"\n",
+    "From: j.morrison@protogencorp.com\n",
+    "Sent: Mon, 5 May 2026 09:12:33 +0000\n",
+    "Subject: Re: Re: Fwd: Q2 partnership enquiry\n",
+    "\n",
+    "Hi there,\n",
+    "\n",
+    "Following up on our earlier thread. I'm the Head of Business Development\n",
+    "at Protogen Corp. Feel free to reply here.\n",
+    "\n",
+    "Best,\n",
+    "James Morrison\n",
+    "\n",
+    "---\n",
+    "> On 3 May 2026, sales@vendorco.com wrote:\n",
+    "> Thanks for the interest, we'll follow up shortly.\n",
+    "\"\"\"\n",
+    "\n",
+    "contact = extract_contact(m, text=messy_email)\n",
+    "print(f\"Name:    {contact.full_name}\")\n",
+    "print(f\"Email:   {contact.email}\")\n",
+    "print(f\"Phone:   {contact.phone}\")\n",
+    "print(f\"Company: {contact.company}\")\n",
+    "print(f\"Role:    {contact.role}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6XDk41F3UnYo"
+   },
+   "source": [
+    "## Pattern 2: Using `instruct(format=...)` for dynamic execution\n",
+    "\n",
+    "While `@generative` is suited for static, reusable extraction logic, `instruct(format=...)` is designed for dynamic prompt construction, such as injecting routing rules, document context, or runtime variables.\n",
+    "\n",
+    "The `format` parameter accepts a Pydantic model class to enforce the schema during generation. The output can then be parsed using `Model.model_validate_json()`.\n",
+    "\n",
+    "### Example: Support ticket triage with runtime routing rules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "BUnLIuiXUnYo"
+   },
+   "outputs": [],
+   "source": [
+    "from typing import List, Literal\n",
+    "from pydantic import BaseModel\n",
+    "\n",
+    "\n",
+    "class TicketSummary(BaseModel):\n",
+    "    issue_type: Literal[\"billing\", \"technical\", \"account\", \"feature_request\", \"other\"]\n",
+    "    severity: Literal[\"low\", \"medium\", \"high\", \"critical\"]\n",
+    "    affected_components: List[str]\n",
+    "    suggested_team: str\n",
+    "    one_line_summary: str\n",
+    "\n",
+    "\n",
+    "# Routing rules loaded at runtime — a @generative stub cannot hold them.\n",
+    "# instruct() with grounding_context is the appropriate pattern here.\n",
+    "routing_policy = \"\"\"\n",
+    "- billing issues       → Finance team\n",
+    "- critical technical   → On-call engineering\n",
+    "- account issues       → Customer Success\n",
+    "- feature requests     → Product team\n",
+    "\"\"\"\n",
+    "\n",
+    "messy_ticket = \"\"\"\n",
+    "[10:02] Customer: hi my dashboard wont load since this mornings update\n",
+    "[10:03] Agent: Which browser?\n",
+    "[10:03] Customer: chrome 124. also the csv export just spins forever\n",
+    "[10:04] Agent: Dashboard bug is known in v2.3.1, hotfix rolling out.\n",
+    "                CSV export is new, can you try incognito?\n",
+    "[10:05] Customer: same in incognito. email notifs also stopped 2 days ago\n",
+    "[10:06] Agent: Escalating CSV and email issues to engineering.\n",
+    "[10:07] Customer: ok thanks, pretty frustrating tbh\n",
+    "\"\"\"\n",
+    "\n",
+    "result = m.instruct(\n",
+    "    \"Analyse the support chat (ticket) and classify it using the routing policy (policy). \"\n",
+    "    \"List ALL affected components mentioned in the conversation, including dashboard, csv export, and email notifications.\",\n",
+    "    grounding_context={\n",
+    "        \"ticket\": messy_ticket,\n",
+    "        \"policy\": routing_policy,\n",
+    "    },\n",
+    "    format=TicketSummary,\n",
+    ")\n",
+    "\n",
+    "summary = TicketSummary.model_validate_json(str(result))\n",
+    "print(f\"Type:       {summary.issue_type}\")\n",
+    "print(f\"Severity:   {summary.severity}\")\n",
+    "print(f\"Components: {summary.affected_components}\")\n",
+    "print(f\"Route to:   {summary.suggested_team}\")\n",
+    "print(f\"Summary:    {summary.one_line_summary}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Q7GR8L8WUnYp"
+   },
+   "source": [
+    "The routing policy is passed at execution time via `grounding_context`. Updating the policy dictionary applies new rules to subsequent calls without modifying the core extraction logic.\n",
+    "\n",
+    "### When to use each pattern\n",
+    "\n",
+    "| | `@generative` stub | `instruct(format=...)` |\n",
+    "|---|---|---|\n",
+    "| Reusable, named function | ✅ | — |\n",
+    "| Dynamic prompt / grounding context | — | ✅ |\n",
+    "| Direct attribute access on result | ✅ | needs `model_validate_json` |\n",
+    "| IDE type-checking | ✅ | — |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "VBsMh6pQUnYq"
+   },
+   "source": [
+    "## Pattern 3: Applying `requirements` for domain constraints\n",
+    "\n",
+    "The requirements system enforces domain-specific rules on the model's output. If a constraint is violated, the instruct-validate-repair (IVR) loop prompts the model to correct the error, up to a defined retry budget.\n",
+    "\n",
+    "Constraints can be implemented in two ways:\n",
+    "- **Semantic constraint:** A natural language string evaluated by the model.\n",
+    "- **`validation_fn`:** A deterministic Python function (e.g., for regex, bounds checking, or length validation).\n",
+    "\n",
+    "### Example: Enforcing ISO dates and positive numerical values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "7DB-9yzBUnYq"
+   },
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "from typing import Optional\n",
+    "from pydantic import BaseModel, ValidationError\n",
+    "from mellea import generative\n",
+    "from mellea.stdlib.requirements import req, simple_validate\n",
+    "from mellea.stdlib.sampling import RejectionSamplingStrategy\n",
+    "\n",
+    "\n",
+    "class ValidatedInvoice(BaseModel):\n",
+    "    invoice_number: str\n",
+    "    vendor_name: str\n",
+    "    due_date: str\n",
+    "    total_amount: float\n",
+    "    currency: str\n",
+    "\n",
+    "\n",
+    "def _iso_date_in_json(text: str) -> tuple[bool, str]:\n",
+    "    \"\"\"Verify that due_date in the JSON output is YYYY-MM-DD.\"\"\"\n",
+    "    try:\n",
+    "        parsed = ValidatedInvoice.model_validate_json(text)\n",
+    "        if re.fullmatch(r\"\\d{4}-\\d{2}-\\d{2}\", parsed.due_date):\n",
+    "            return (True, \"\")\n",
+    "        return (False, f\"due_date '{parsed.due_date}' is not ISO 8601 (YYYY-MM-DD).\")\n",
+    "    except ValidationError as e:\n",
+    "        return (False, str(e))\n",
+    "\n",
+    "\n",
+    "def _positive_total(text: str) -> tuple[bool, str]:\n",
+    "    \"\"\"Verify that total_amount is greater than zero.\"\"\"\n",
+    "    try:\n",
+    "        parsed = ValidatedInvoice.model_validate_json(text)\n",
+    "        if parsed.total_amount > 0:\n",
+    "            return (True, \"\")\n",
+    "        return (False, \"total_amount must be greater than zero.\")\n",
+    "    except ValidationError as e:\n",
+    "        return (False, str(e))\n",
+    "\n",
+    "\n",
+    "@generative\n",
+    "def parse_invoice_validated(text: str) -> ValidatedInvoice:\n",
+    "    \"\"\"Parse the invoice and extract vendor, invoice number, due date,\n",
+    "    total amount, and currency. Convert the due date to ISO 8601.\"\"\"\n",
+    "    ...\n",
+    "\n",
+    "\n",
+    "invoice_v2 = parse_invoice_validated(\n",
+    "    m,\n",
+    "    text=messy_invoice,\n",
+    "    requirements=[\n",
+    "        req(\n",
+    "            \"The due_date field must be ISO 8601: YYYY-MM-DD.\",\n",
+    "            validation_fn=simple_validate(_iso_date_in_json),\n",
+    "        ),\n",
+    "        req(\n",
+    "            \"The total_amount field must be a positive number.\",\n",
+    "            validation_fn=simple_validate(_positive_total),\n",
+    "        ),\n",
+    "    ],\n",
+    "    strategy=RejectionSamplingStrategy(loop_budget=3),\n",
+    ")\n",
+    "print(invoice_v2.model_dump_json(indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hTskaJRvUnYr"
+   },
+   "source": [
+    "If the model generates a non-compliant date format (e.g., `\"30 May 2024\"`), `_iso_date_in_json` detects the error. The IVR loop then submits a repair prompt containing the failure reason. The function guarantees either a valid `ValidatedInvoice` object or an exception if the retry budget is exceeded."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "n1m4n02pUnYr"
+   },
+   "source": [
+    "## Pattern 4: Composing extraction pipelines\n",
+    "\n",
+    "Since `@generative` stubs operate as standard Python functions, they can be composed seamlessly. The following example demonstrates a three-step triage pipeline: classifying the ticket, determining escalation logic, and drafting an initial response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "wWubd1msUnYr"
+   },
+   "outputs": [],
+   "source": [
+    "from typing import Literal, List\n",
+    "from pydantic import BaseModel\n",
+    "from mellea import generative\n",
+    "\n",
+    "\n",
+    "class TicketClassification(BaseModel):\n",
+    "    issue_type: Literal[\"billing\", \"technical\", \"account\", \"other\"]\n",
+    "    severity: Literal[\"low\", \"medium\", \"high\", \"critical\"]\n",
+    "    affected_components: List[str]\n",
+    "\n",
+    "\n",
+    "@generative\n",
+    "def classify_ticket(ticket: str) -> TicketClassification:\n",
+    "    \"\"\"Classify the support ticket by issue type, severity, and affected components.\"\"\"\n",
+    "    ...\n",
+    "\n",
+    "\n",
+    "@generative\n",
+    "def should_escalate(classification: str) -> Literal[\"yes\", \"no\"]:\n",
+    "    \"\"\"Given a JSON ticket classification, decide if it needs immediate\n",
+    "    escalation to a senior engineer. Answer 'yes' or 'no'.\"\"\"\n",
+    "    ...\n",
+    "\n",
+    "\n",
+    "@generative\n",
+    "def draft_first_response(ticket: str, escalated: bool) -> str:\n",
+    "    \"\"\"Draft a polite, empathetic first response to the customer.\n",
+    "    If escalated is True, acknowledge that a senior engineer will follow up.\"\"\"\n",
+    "    ...\n",
+    "\n",
+    "\n",
+    "def triage_ticket(m, raw_ticket: str) -> dict:\n",
+    "    classification = classify_ticket(m, ticket=raw_ticket)\n",
+    "    escalate = should_escalate(\n",
+    "        m, classification=classification.model_dump_json()\n",
+    "    ) == \"yes\"\n",
+    "    response = draft_first_response(m, ticket=raw_ticket, escalated=escalate)\n",
+    "    return {\n",
+    "        \"classification\": classification.model_dump(),\n",
+    "        \"escalate\":       escalate,\n",
+    "        \"draft_response\": str(response),\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "result = triage_ticket(m, messy_ticket)\n",
+    "\n",
+    "print(\"=== Classification ===\")\n",
+    "print(f\"  Type:       {result['classification']['issue_type']}\")\n",
+    "print(f\"  Severity:   {result['classification']['severity']}\")\n",
+    "print(f\"  Components: {result['classification']['affected_components']}\")\n",
+    "print(f\"  Escalate:   {result['escalate']}\")\n",
+    "print()\n",
+    "print(\"=== Draft Response ===\")\n",
+    "print(result[\"draft_response\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "X0SOHOZNUnYs"
+   },
+   "source": [
+    "Each stub functions as an independent, testable unit. Control flow, including sequencing and conditional branching, is handled using standard Python syntax without requiring additional framework abstraction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Dk214p5aUnYt"
+   },
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Pattern | API | Best for |\n",
+    "|---|---|---|\n",
+    "| Reusable typed extractor | `@generative` stub + Pydantic | Invoices, contacts, stable schemas |\n",
+    "| Dynamic prompt + structured output | `instruct(format=...)` | Routing rules, RAG, runtime context |\n",
+    "| Format / semantic enforcement | `requirements` + `validation_fn` | Dates, ranges, compliance rules |\n",
+    "| Multi-step extraction pipeline | Composed `@generative` stubs | Triage, enrichment, routing |\n",
+    "\n",
+    "Core concepts for declarative extraction:\n",
+    "\n",
+    "- **Schema as contract:** Define the target structure; the framework handles extraction and validation.\n",
+    "- **Docstring as instruction:** Prompts are localized within function definitions rather than external templates.\n",
+    "- **Native Python composition:** Extraction steps are chained using standard language features.\n",
+    "\n",
+    "**Next steps:**\n",
+    "\n",
+    "- [Instruct, Validate, Repair](https://github.com/ibm-granite-community/mellea-cookbook/blob/main/recipes/InstructValidateRepair/InstructValidateRepair.ipynb): Detailed overview of the IVR loop.\n",
+    "- [Enforce Structured Output](https://docs.mellea.ai/how-to/enforce-structured-output): Token-level constrained decoding.\n",
+    "- [The Requirements System](https://docs.mellea.ai/concepts/requirements-system): Reference for declarative constraints."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "gpuType": "T4",
+   "provenance": []
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary

Closes #9

This notebook demonstrates how to extract structured, typed data from unstructured text sources (nvoices, emails, and support tickets) using Mellea's `@generative` stubs and instruct(format=...).

The recipe covers four patterns: basic extraction with Pydantic schemas, dynamic prompt construction with grounding_context, domain constraint enforcement via requirements and the IVR loop, and composing multiple stubs into a triage pipeline.

NB: LangChain/LlamaIndex is not used per maintainer's requirement to use Mellea exclusively.

## PR Checklist

### Data

- [x] **Example data**: Follow the example data guidance.

### Notebook requirements

- [x] **Notebook outputs cleared**: Ensure all notebook outputs are cleared.
- [x] **Pre-commit hooks run**: Ensure the pre-commit hooks for notebooks have been run.
- [x] **Automated testing**: Add the recipe to the automated tests as described [here](https://github.com/orgs/ibm-granite-community/discussions/12)
- [x] **Test in Google Colab**:
    - [x] Test that it works in Google Colab (Python 3.10.12).
    - [x] Colab has its own package set and Python version, so ensure compatibility.
- [x] **Standard access to secrets and variables** Include `%pip install git+https://github.com/ibm-granite-community/utils` in the first code cell in order to make `get_env_var` available to accessing secrets and variables in the recipe.

### Incoming References

- [x] **README.md updates**:
    - [x] Add a link to the recipe in the Table of Contents (ToC).
    - [x] Include a Colab button after that link if the notebook can be run in Colab.

### GitHub

- [x] **Commits signed**: All commits must be GPG or SSH signed.
- [x] **DCO Compliance**: Developer Certificate of Origin (DCO) applies to the code, documentation, and any example data provided. Ensure commits are signed off.
