### PR TITLE
fix(IVR): support ollama local backend, fix stdlib.requirements import

### DIFF
--- a/recipes/InstructValidateRepair/InstructValidateRepair.ipynb
+++ b/recipes/InstructValidateRepair/InstructValidateRepair.ipynb
@@ -86,7 +86,7 @@
     "! echo \"::group::Install Dependencies\"\n",
     "%pip install uv\n",
     "! uv pip install \"git+https://github.com/ibm-granite-community/utils.git\" \\\n",
-    "    \"mellea[litellm]\"\n",
+    "    \"mellea[ollama]\"\n",
     "! echo \"::endgroup::\""
    ]
   },
@@ -105,12 +105,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ibm_granite_community.notebook_utils import get_env_var\n",
-    "\n",
-    "# Load credentials into environment variables\n",
-    "get_env_var(\"WATSONX_APIKEY\")\n",
-    "get_env_var(\"WATSONX_PROJECT_ID\")\n",
-    "get_env_var(\"WATSONX_URL\")\n"
+    "# No credentials needed for local ollama backend\n",
+    "print(\"Using local ollama backend — no API keys required.\")\n"
    ]
   },
   {
@@ -128,11 +124,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mellea import start_session, MelleaSession\n",
+    "from mellea import start_session, MelleaSession, model_ids\n",
     "\n",
     "m: MelleaSession = start_session(\n",
-    "        backend_name=\"litellm\",\n",
-    "        model_id=\"watsonx/ibm/granite-4-h-small\",\n",
+    "        backend_name=\"ollama\",\n",
+    "        model_id=model_ids.IBM_GRANITE_4_1_3B,  # ollama_name = 'granite4.1:3b'\n",
     "    )\n"
    ]
   },
@@ -282,7 +278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mellea.stdlib.requirement import check, req, simple_validate\n",
+    "from mellea.stdlib.requirements import check, req, simple_validate\n",
     "\n",
     "requirements = [\n",
     "            req(\"The email should have a salutation\"), # r1\n",
@@ -378,6 +374,11 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
@@ -387,7 +388,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the Instruct-Validate-Repair notebook that prevent it from running locally without watsonx credentials.

### Problems fixed

| Cell | Problem | Fix |
|---|---|---|
| Install | `mellea[litellm]` installed — ollama SDK missing | Changed to `mellea[ollama]` |
| Credentials | `get_env_var(WATSONX_*)` blocks run for users without watsonx access | Replaced with a no-op `print()` for local backend |
| Session | Hardcoded `litellm` backend + watsonx model ID | Switched to `ollama` backend + `model_ids.IBM_GRANITE_4_1_3B` |
| Step 5 import | `from mellea.stdlib.requirement import ...` — module does not exist | Fixed to `from mellea.stdlib.requirements import ...` |

### Tested

- macOS, Apple M3 Pro, 28 GB RAM
- Python 3.13.12 in venv
- ollama 0.32.14, granite4.1:3b (2.1 GB)
- All cells ran end-to-end via Kernel → Restart & Run All

### Notes

- Markdown cells still reference watsonx/LiteLLM as context — left unchanged
- `granite4.1:3b` works on most machines (8 GB+ RAM); `granite4.1:8b` is a better model but requires 32 GB+
- No API keys or cloud accounts required

Closes #<!-- issue number if one exists -->